### PR TITLE
Adds support for filter CSS property with SPANS renderer

### DIFF
--- a/packages/text-annotator/src/highlight/HighlightStyle.ts
+++ b/packages/text-annotator/src/highlight/HighlightStyle.ts
@@ -10,7 +10,8 @@ export interface HighlightStyle extends Pick<DrawingStyle, 'fill' | 'fillOpacity
   underlineOffset?: number;
 
   underlineThickness?: number;
-  
+
+  filter?: string;
 }
 
 export type HighlightStyleExpression = HighlightStyle 

--- a/packages/text-annotator/src/highlight/span/spansRenderer.ts
+++ b/packages/text-annotator/src/highlight/span/spansRenderer.ts
@@ -89,6 +89,9 @@ const createRenderer = (container: HTMLElement): RendererImplementation => {
             .alpha(style?.fillOpacity === undefined ? DEFAULT_STYLE.fillOpacity : style.fillOpacity)
             .toHex();
 
+          if (style.filter)
+            span.style.filter = style.filter;
+
           if (style.underlineStyle)
             span.style.borderStyle = style.underlineStyle;
 


### PR DESCRIPTION
I'd like to apply a filter like `contrast(200%) grayscale(100%) invert(100%) contrast(200%)` to essentially highlight with white text on a black background. This seems to be all that's required to provide support for additional styling of the `<span>` elements - can you confirm?