### PR TITLE
TECH-1773 Added support for `migrationPending` property in W3C annotation targets

### DIFF
--- a/packages/text-annotator/src/model/w3c/W3CTextAnnotation.ts
+++ b/packages/text-annotator/src/model/w3c/W3CTextAnnotation.ts
@@ -12,12 +12,13 @@ export interface W3CTextAnnotationTarget extends W3CAnnotationTarget {
 
   selector: W3CTextSelector | W3CTextSelector[];
 
-  outdated?: boolean;
-
   styleClass?: string;
 
   scope?: string;
 
+  // Soomo-Specific properties
+  outdated?: boolean;
+  migrationPending?: boolean;
 }
 
 /**

--- a/packages/text-annotator/src/model/w3c/W3CTextFormatAdapter.ts
+++ b/packages/text-annotator/src/model/w3c/W3CTextFormatAdapter.ts
@@ -68,8 +68,11 @@ const parseW3CTextTargets = (annotation: W3CTextAnnotation) => {
       return s;
     }, {});
 
+    // Soomo-specific properties
     // @ts-expect-error: `outdated` is not part of the core `TextAnnotationTarget` type
     parsed.outdated ||= "outdated" in w3cTarget ? w3cTarget.outdated : undefined;
+    // @ts-expect-error: `migrationPending` is not part of the core `TextAnnotationTarget` type
+    parsed.migrationPending ||= "migrationPending" in w3cTarget ? w3cTarget.migrationPending : undefined;
 
     if (isTextSelector(selector)) {
       parsed.selector.push(


### PR DESCRIPTION
## Changes Made
Added new soomo-specific `migrationPending` field to serialized annotation `target`.

Otherwise, the new field won't be carried over to the annotator's internal store.

## Relations
This PR follows a similar pattern to https://github.com/oleksandr-danylchenko/text-annotator-js/pull/1